### PR TITLE
Dont rely on '\n' in echo statements

### DIFF
--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -1,15 +1,19 @@
 ## Post build script
 echo 'Initiating post-build sequence'
 
-cp third_party/zxing-js.umd.min.js minified/html5-qrcode.min.js
+echo '/** ZXing **/' > minified/html5-qrcode.min.js
+cat third_party/zxing-js.umd.min.js >> minified/html5-qrcode.min.js
 echo 'Copied third_party/zxing-js.umd.min.js to minified/html5-qrcode.min.js'
 
 ## Copy all other temp files to final minified script
+
+echo  >> minified/html5-qrcode.min.js
+echo '/** Html5Qrcode **/' >> minified/html5-qrcode.min.js
 cat minified/html5-qrcode.tmp.js >> minified/html5-qrcode.min.js
 echo 'Copied minified/html5-qrcode.tmp.js to minified/html5-qrcode.min.js'
 
-echo '\n\n/** Html5QrcodeScanner **/' >> minified/html5-qrcode.min.js
-
+echo  >> minified/html5-qrcode.min.js
+echo '/** Html5QrcodeScanner **/' >> minified/html5-qrcode.min.js
 cat minified/html5-qrcode-scanner.tmp.js >> minified/html5-qrcode.min.js
 echo 'Copied minified/html5-qrcode-scanner.tmp.js to minified/html5-qrcode.min.js'
 


### PR DESCRIPTION
As mentioned in https://github.com/mebjas/html5-qrcode/pull/169, some are having some issues with the transpiling. Appearantly there are different implementations of `echo` that may behave differently. According to the [(not really) official documentation](https://stackoverflow.com/a/8467449/689893), `printf` may be a more reliable alternative.