### PR TITLE
Update test for ZXing refactor

### DIFF
--- a/test/test.html5-qrcode.html
+++ b/test/test.html5-qrcode.html
@@ -17,8 +17,8 @@
     <script src="../node_modules/promise-polyfill/dist/polyfill.min.js"></script>
 
     <!-- actual library code -->
-    <script src="../third_party/qrcode.min.js"></script>
-    <script src="../transpiled/html5-qrcode.js"></script>
+    <script  type="application/javascript" src="../third_party/zxing-js.umd.min.js"></script>
+    <script  type="application/javascript" src="../transpiled/html5-qrcode.js"></script>
 
     <!-- test dependencies -->
     <script src="../node_modules/mocha/mocha.js"></script>

--- a/test/test.html5-qrcode.js
+++ b/test/test.html5-qrcode.js
@@ -14,11 +14,10 @@ describe('Constructor', function()  {
         assert.notEqual(html5Qrcode, undefined);
     });
 
-    it('Constructor fails if qrcode not defined', function() {
-        const expectedErrorMessage = "qrcode is not defined, use the minified"
-            + "/html5-qrcode.min.js for proper support";
-        const __getLazarSoftScanner = getLazarSoftScanner;
-        getLazarSoftScanner = function() { return undefined; };
+    it('Constructor fails if ZXing not defined', function() {
+        const expectedErrorMessage = "Use html5qrcode.min.js without edit, ZXing not found.";
+        const __ZXing = ZXing;
+        ZXing = undefined;
         try {
             new Html5Qrcode("qr");
             assert.fail("exception should be thrown");
@@ -26,7 +25,7 @@ describe('Constructor', function()  {
             assert.equal(exception, expectedErrorMessage);
         }
 
-        getLazarSoftScanner = __getLazarSoftScanner;
+        ZXing = __ZXing;
     });
 
     describe('Verbosity is set', function()  {


### PR DESCRIPTION
As discussed in https://github.com/mebjas/html5-qrcode/pull/169 a test is failing. I believe this is due to an incomplete migration to ZXing. With these changed as test success when I open `test/test.html5-qrcode.html` directly. But I am still getting an error on `npm run test`. I not familiar enough with mocha or phanthomjs to resolve this right now. 