### PR TITLE
Fix 5px gap on bottom 90-degree brackets of qrbox

### DIFF
--- a/src/html5-qrcode.ts
+++ b/src/html5-qrcode.ts
@@ -1432,14 +1432,14 @@ export class Html5Qrcode {
                 shadingElement,
                 /* width= */ largeSize,
                 /* height= */ smallSize,
-                /* top= */ qrboxSize.height + smallSize,
+                /* top= */ qrboxSize.height,
                 /* side= */ 0,
                 /* isLeft= */ true);
             this.insertShaderBorders(
                 shadingElement,
                 /* width= */ largeSize,
                 /* height= */ smallSize,
-                /* top= */ qrboxSize.height + smallSize,
+                /* top= */ qrboxSize.height,
                 /* side= */ 0,
                 /* isLeft= */ false);
             this.insertShaderBorders(
@@ -1453,7 +1453,7 @@ export class Html5Qrcode {
                 shadingElement,
                 /* width= */ smallSize,
                 /* height= */ largeSize + smallSize,
-                /* top= */ qrboxSize.height + smallSize - largeSize,
+                /* top= */ qrboxSize.height - largeSize,
                 /* side= */ -smallSize,
                 /* isLeft= */ true);
             this.insertShaderBorders(
@@ -1467,7 +1467,7 @@ export class Html5Qrcode {
                 shadingElement,
                 /* width= */ smallSize,
                 /* height= */ largeSize + smallSize,
-                /* top= */ qrboxSize.height + smallSize - largeSize,
+                /* top= */ qrboxSize.height - largeSize,
                 /* side= */ -smallSize,
                 /* isLeft= */ false);
             this.hasBorderShaders = true;


### PR DESCRIPTION
The pair of 90-degree brackets on the bottom of `qrbox` are nudged 5px too far down. This should (I'm like 90% sure) fix that, by pulling those two brackets (four individual pieces) back upward by 5px. Definitely check my work, but based on the other values for each object, I think this should fix it.

Below is a screenshot/example of what this aims to fix. Let me know if you have any questions, here!

![image](https://user-images.githubusercontent.com/13950848/136712238-84610e9c-7eae-46fe-b696-7355b3e337ab.png)