### PR TITLE
fix: set default value of config.supportedScanTypes

### DIFF
--- a/src/html5-qrcode-scanner.ts
+++ b/src/html5-qrcode-scanner.ts
@@ -387,6 +387,10 @@ export class Html5QrcodeScanner {
                     = Html5QrcodeConstants.DEFAULT_REMEMBER_LAST_CAMERA_USED;
             }
 
+            if (!config.supportedScanTypes) {
+                config.supportedScanTypes = Html5QrcodeConstants.DEFAULT_SUPPORTED_SCAN_TYPE;
+            }
+
             return config;
         }
 


### PR DESCRIPTION
@mebjas 

This solves the issue reported on #494 where `config.supportedScanTypes` is not set to a default value like other config properties.

@all-contributors please add @rlueder for this new feature or tests