### PR TITLE
Fix qrbox border placement

### DIFF
--- a/src/html5-qrcode.ts
+++ b/src/html5-qrcode.ts
@@ -1563,6 +1563,7 @@ export class Html5Qrcode {
                 /* width= */ largeSize, 
                 /* height= */ smallSize,
                 /* top= */ -smallSize,
+                /* bottom= */ null,
                 /* side= */ 0,
                 /* isLeft= */ true);
             this.insertShaderBorders(
@@ -1570,20 +1571,23 @@ export class Html5Qrcode {
                 /* width= */ largeSize,
                 /* height= */ smallSize,
                 /* top= */ -smallSize,
+                /* bottom= */ null,
                 /* side= */ 0,
                 /* isLeft= */ false);
             this.insertShaderBorders(
                 shadingElement,
                 /* width= */ largeSize,
                 /* height= */ smallSize,
-                /* top= */ qrboxSize.height + smallSize,
+                /* top= */ null,
+                /* bottom= */ -smallSize,
                 /* side= */ 0,
                 /* isLeft= */ true);
             this.insertShaderBorders(
                 shadingElement,
                 /* width= */ largeSize,
                 /* height= */ smallSize,
-                /* top= */ qrboxSize.height + smallSize,
+                /* top= */ null,
+                /* bottom= */ -smallSize,
                 /* side= */ 0,
                 /* isLeft= */ false);
             this.insertShaderBorders(
@@ -1591,13 +1595,15 @@ export class Html5Qrcode {
                 /* width= */ smallSize,
                 /* height= */ largeSize + smallSize,
                 /* top= */ -smallSize,
+                /* bottom= */ null,
                 /* side= */ -smallSize,
                 /* isLeft= */ true);
             this.insertShaderBorders(
                 shadingElement,
                 /* width= */ smallSize,
                 /* height= */ largeSize + smallSize,
-                /* top= */ qrboxSize.height + smallSize - largeSize,
+                /* top= */ null,
+                /* bottom= */ -smallSize,
                 /* side= */ -smallSize,
                 /* isLeft= */ true);
             this.insertShaderBorders(
@@ -1605,13 +1611,15 @@ export class Html5Qrcode {
                 /* width= */ smallSize,
                 /* height= */ largeSize + smallSize,
                 /* top= */ -smallSize,
+                /* bottom= */ null,
                 /* side= */ -smallSize,
                 /* isLeft= */ false);
             this.insertShaderBorders(
                 shadingElement,
                 /* width= */ smallSize,
                 /* height= */ largeSize + smallSize,
-                /* top= */ qrboxSize.height + smallSize - largeSize,
+                /* top= */ null,
+                /* bottom= */ -smallSize,
                 /* side= */ -smallSize,
                 /* isLeft= */ false);
             this.hasBorderShaders = true;
@@ -1623,7 +1631,8 @@ export class Html5Qrcode {
         shaderElem: HTMLDivElement,
         width: number,
         height: number,
-        top: number,
+        top: number|null,
+        bottom: number|null,
         side: number,
         isLeft: boolean) {
         const elem = document.createElement("div");
@@ -1631,7 +1640,12 @@ export class Html5Qrcode {
         elem.style.backgroundColor = Constants.BORDER_SHADER_DEFAULT_COLOR;
         elem.style.width = `${width}px`;
         elem.style.height = `${height}px`;
-        elem.style.top = `${top}px`;
+        if (top !== null) {
+            elem.style.top = `${top}px`;
+        }
+        if (bottom !== null) {
+            elem.style.bottom = `${bottom}px`;
+        }
         if (isLeft) {
           elem.style.left = `${side}px`;
         } else {

--- a/src/html5-qrcode.ts
+++ b/src/html5-qrcode.ts
@@ -1461,6 +1461,7 @@ export class Html5Qrcode {
     private createVideoElement(width: number): HTMLVideoElement {
         const videoElement = document.createElement("video");
         videoElement.style.width = `${width}px`;
+        videoElement.style.display = "block";
         videoElement.muted = true;
         videoElement.setAttribute("muted", "true");
         (<any>videoElement).playsInline = true;


### PR DESCRIPTION
First commit fix an issue where the wrapping element of the video element added some whitespaces and made the qrbox overflow. ref: https://stackoverflow.com/a/36397260
<img width="506" alt="Screenshot 2022-10-13 at 11 12 12" src="https://user-images.githubusercontent.com/3891597/195561042-c505eda4-1334-4f97-85f9-cfafb93be5d6.png">
<img width="578" alt="Screenshot 2022-10-13 at 11 13 25" src="https://user-images.githubusercontent.com/3891597/195561069-b8767980-c3da-4caa-8317-79a50adb3a63.png">

Second commit now fix an issue raised by the first fix, the qrbox borders are based on the size of the viewFinder size, problem is when the viewFinder height has a floating point the position of the 4 bottom borders are now based on half of a rounder floating number.

[This PR](https://github.com/mebjas/html5-qrcode/pull/307) also had the issue with 5px too much, this is because the 4 bottom borders where placed in relation to the viewFinder area + adding 5px to compensate the whitespace from the video element.

Final result:
<img width="480" alt="Screenshot 2022-10-13 at 11 35 08" src="https://user-images.githubusercontent.com/3891597/195561133-0c39aa40-7db2-45f3-975c-ede57df89d2b.png">