### PR TITLE
Hide CameraSelectionContainer when only one camera

### DIFF
--- a/src/html5-qrcode-scanner.ts
+++ b/src/html5-qrcode-scanner.ts
@@ -704,7 +704,7 @@ export class Html5QrcodeScanner {
                 "select", this.getCameraSelectionId());
         if (numCameras === 1) {
             // If only one camera is found, don't show camera selection.
-            cameraSelectionSelect.style.display = "none";
+            cameraSelectionContainer.style.display = "none";
         } else {
             // Otherwise, show the number of cameras found as well.
             const selectCameraString = Html5QrcodeScannerStrings.selectCamera();


### PR DESCRIPTION
Before, it seemed to be creating an empty span with a margin of 10px.  This makes it so that span is hidden.

For  #599