### PR TITLE
Add await to this.surface.play()

### DIFF
--- a/src/camera/core-impl.ts
+++ b/src/camera/core-impl.ts
@@ -186,7 +186,7 @@ class RenderedCameraImpl implements RenderedCamera {
 
         this.surface.addEventListener("playing", onVideoStart);
         this.surface.srcObject = this.mediaStream;
-        this.surface.play();
+        return this.surface.play();
     }
 
     static async create(
@@ -205,7 +205,7 @@ class RenderedCameraImpl implements RenderedCamera {
                 aspectRatioConstraint);
         }
 
-        renderedCamera.setupSurface();
+        await renderedCamera.setupSurface();
         return renderedCamera;
     }
 


### PR DESCRIPTION
When we call the `start` function of the `Html5QrCode` object, the promise was resolved **before** the video from the camera is ready/rendered, thus making it currently not possible to chain the promise of the `start` function with other operations like `stop`, `pause`, etc.

Also, the exceptions thrown inside .play() promise were not being handled

### Before (Chaining with pause)
```javascript
const qrCode = new Html5Qrcode('reader-id')

qrCode.start(
    { facingMode: 'environment' },
    { fps: 10 },
    () => {},
    () => {}
    ).then(
        () => qrCode.pause()
    );
```
<img width="1918" alt="Screen Shot 2565-12-12 at 19 19 25" src="https://user-images.githubusercontent.com/82935610/207045197-31cf8c91-cef1-4382-a740-9356527d54b9.png">

### After (Chaining with pause)

<img width="1920" alt="Screen Shot 2565-12-12 at 19 14 44" src="https://user-images.githubusercontent.com/82935610/207045346-f95a151b-1e96-4ca6-975c-39e28b0ba344.png">

### Before (Chaining with stop)
```javascript
const qrCode = new Html5Qrcode('reader-id')

qrCode.start(
    { facingMode: 'environment' },
    { fps: 10 },
    () => {},
    () => {}
    ).then(
        () => qrCode.stop()
    );
```
<img width="1918" alt="Screen Shot 2565-12-12 at 19 22 15" src="https://user-images.githubusercontent.com/82935610/207045467-032766ae-c3c9-4f47-a19a-0804335f6457.png">

### After (Chaining with stop)

<img width="1919" alt="Screen Shot 2565-12-12 at 19 23 16" src="https://user-images.githubusercontent.com/82935610/207045511-fbd52a6c-8644-434e-b09c-c476d55ac571.png">
