### PR TITLE
Exposing state transitions through an optional callback arg within the Html5Qrcode constructor

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -8,6 +8,8 @@
  * http://www.denso-wave.com/qrcode/faqpatent-e.html
  */
 
+import { Html5QrcodeScannerState } from "./state-manager";
+
 /**
  * Code formats supported by this library.
  */
@@ -249,6 +251,13 @@ export type QrcodeSuccessCallback
  */
 export type QrcodeErrorCallback
     = (errorMessage: string, error: Html5QrcodeError) => void;
+
+/**
+ * Type for a callback for scanner state transition.
+ */
+export type QrCodeStateCallback
+    = (currentState: Html5QrcodeScannerState) => void;
+
 
 /** Code decoder interface. */
 export interface QrcodeDecoderAsync {

--- a/src/html5-qrcode.ts
+++ b/src/html5-qrcode.ts
@@ -26,7 +26,8 @@ import {
     Html5QrcodeResult,
     isNullOrUndefined,
     QrDimensions,
-    QrDimensionFunction
+    QrDimensionFunction,
+    QrCodeStateCallback
 } from "./core";
 import { Html5QrcodeStrings } from "./strings";
 import { VideoConstraintsUtil } from "./utils";
@@ -309,7 +310,7 @@ export class Html5Qrcode {
      * TODO(mebjas): Deprecate the verbosity boolean flag completely.
      */
     public constructor(elementId: string, 
-        configOrVerbosityFlag?: boolean | Html5QrcodeFullConfig | undefined) {
+        configOrVerbosityFlag?: boolean | Html5QrcodeFullConfig | undefined, qrCodeStateCallback?: QrCodeStateCallback | undefined,) {
         if (!document.getElementById(elementId)) {
             throw `HTML Element with id=${elementId} not found`;
         }
@@ -336,7 +337,7 @@ export class Html5Qrcode {
 
         this.foreverScanTimeout;
         this.shouldScan = true;
-        this.stateManagerProxy = StateManagerFactory.create();
+        this.stateManagerProxy = StateManagerFactory.create(qrCodeStateCallback);
     }
 
     //#region start()

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -84,14 +84,16 @@ class StateManagerImpl implements StateManager, StateManagerTransaction {
         * QrCodeStateCallback}
         */
     constructor(qrCodeStateCallback?: QrCodeStateCallback | undefined) {
-        this.qrCodeStateCallback = qrCodeStateCallback
+        this.qrCodeStateCallback = qrCodeStateCallback;
     }
 
     public directTransition(newState: Html5QrcodeScannerState) {
         this.failIfTransitionOngoing();
         this.validateTransition(newState);
         this.state = newState;
-        if (this.qrCodeStateCallback) this.qrCodeStateCallback(newState)
+        if (this.qrCodeStateCallback) {
+            this.qrCodeStateCallback(newState);
+        }
     }
 
     public startTransition(newState: Html5QrcodeScannerState): StateManagerTransaction {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -5,6 +5,8 @@
  * @author mebjas <minhazav@gmail.com>
  */
 
+import { QrCodeStateCallback } from "./core";
+
 /** Different states of scanner */
 export enum Html5QrcodeScannerState {
     // Invalid internal state, do not set to this state.
@@ -73,10 +75,23 @@ class StateManagerImpl implements StateManager, StateManagerTransaction {
     private onGoingTransactionNewState: Html5QrcodeScannerState
         = Html5QrcodeScannerState.UNKNOWN;
 
+    private qrCodeStateCallback: QrCodeStateCallback | undefined;
+
+    /**
+     * Initialize the state manager.
+     *
+     * @param configOrVerbosityFlag optional, state transition callback {@link
+        * QrCodeStateCallback}
+        */
+    constructor(qrCodeStateCallback?: QrCodeStateCallback | undefined) {
+        this.qrCodeStateCallback = qrCodeStateCallback
+    }
+
     public directTransition(newState: Html5QrcodeScannerState) {
         this.failIfTransitionOngoing();
         this.validateTransition(newState);
         this.state = newState;
+        if (this.qrCodeStateCallback) this.qrCodeStateCallback(newState)
     }
 
     public startTransition(newState: Html5QrcodeScannerState): StateManagerTransaction {
@@ -187,7 +202,7 @@ export class StateManagerProxy {
  * Factory for creating instance of {@class StateManagerProxy}.
  */
  export class StateManagerFactory {
-    public static create(): StateManagerProxy {
-        return new StateManagerProxy(new StateManagerImpl());
+    public static create(qrCodeStateCallback?: QrCodeStateCallback | undefined): StateManagerProxy {
+        return new StateManagerProxy(new StateManagerImpl(qrCodeStateCallback));
     }
 }


### PR DESCRIPTION
Greetings everyone!

Today, while working with `html5-qrcode`, I encountered a particular issue related to state. Upon loading a page, the scanner took around 1 to 2 seconds to load on some devices. To improve the user experience, I intended to add a loader attached to the scanner state. However, I encountered some difficulty using `getState()` to accomplish this task.

I decided to dig through the lib and add an optional state callback arg through the scanner constructor that enables us to observe state changes in real-time and accordingly manage them in the UI.

Please let me know how this can be improved and whether we should even use something like this.

**Note:** I didn't spend much time on this so this is not a complete solution, but I wanted to get your ideas before spending more time on it. I have not tested this. Thank you!!