### PR TITLE
fix fileScanAltText typo error

### DIFF
--- a/src/strings.ts
+++ b/src/strings.ts
@@ -183,7 +183,7 @@ export class Html5QrcodeScannerStrings {
     }
 
     public static fileScanAltText(): string {
-        return "Fule based scan";
+        return "File based scan";
     }
 }
 


### PR DESCRIPTION
change fule into file in the returned string