### PR TITLE
don't show zoomcontrol if step not defined

### DIFF
--- a/src/html5-qrcode-scanner.ts
+++ b/src/html5-qrcode-scanner.ts
@@ -722,6 +722,9 @@ export class Html5QrcodeScanner {
             if (!zoomCapability.isSupported()) {
                 return;
             }
+            if(!zoomCapability.step()){
+                return;
+            }
 
             // Supported.
             cameraZoomUi.setOnCameraZoomValueChangeCallback((zoomValue) => {


### PR DESCRIPTION
Fixes type error undefined is not an object when evaluating i.tostring only occuring on IOS (step is not defined which is called toString later on). This change prevents creating the zoomcontrol.

![image](https://github.com/mebjas/html5-qrcode/assets/3874017/26082282-15fa-4047-874a-20eeb759bd3d)
