### PR TITLE
Support for binary QR codes

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -147,12 +147,44 @@ export interface QrcodeResultDebugData {
     decoderName?: string;
 }
 
+/** types of metadata that can exist in a result */
+export enum ResultMetadataType {
+    OTHER = 0,
+    ORIENTATION = 1,
+    BYTE_SEGMENTS = 2,
+    ERROR_CORRECTION_LEVEL = 3,
+    ISSUE_NUMBER = 4,
+    SUGGESTED_PRICE = 5,
+    POSSIBLE_COUNTRY = 6,
+    UPC_EAN_EXTENSION = 7,
+    PDF417_EXTRA_METADATA = 8,
+    STRUCTURED_APPEND_SEQUENCE = 9,
+    STRUCTURED_APPEND_PARITY = 10
+}
+
+/** metadata for a result, basically a `Map` but with specific key/value pairs */
+export interface ResultMetadata {
+    get (key: ResultMetadataType.OTHER): unknown | undefined;
+    get (key: ResultMetadataType.ORIENTATION): number | undefined;
+    get (key: ResultMetadataType.BYTE_SEGMENTS): Uint8Array[] | undefined;
+    get (key: ResultMetadataType.ERROR_CORRECTION_LEVEL): unknown;
+    get (key: ResultMetadataType.ISSUE_NUMBER): number | undefined;
+    get (key: ResultMetadataType.SUGGESTED_PRICE): string | undefined;
+    get (key: ResultMetadataType.POSSIBLE_COUNTRY): string | undefined;
+    get (key: ResultMetadataType.UPC_EAN_EXTENSION): unknown | undefined;
+    get (key: ResultMetadataType.PDF417_EXTRA_METADATA): unknown | undefined;
+    get (key: ResultMetadataType.STRUCTURED_APPEND_SEQUENCE): unknown | undefined;
+    get (key: ResultMetadataType.STRUCTURED_APPEND_PARITY): unknown | undefined;
+}
+
 /**
  * Detailed scan result.
  */
 export interface QrcodeResult {
     /** Decoded text. */
     text: string;
+
+    metadata?: ResultMetadata;
 
     /** Format that was successfully scanned. */
     format?: QrcodeResultFormat,

--- a/src/zxing-html5-qrcode-decoder.ts
+++ b/src/zxing-html5-qrcode-decoder.ts
@@ -110,6 +110,7 @@ export class ZXingHtml5QrcodeDecoder implements QrcodeDecoderAsync {
         let result = zxingDecoder.decode(binaryBitmap);
         return {
             text: result.text,
+            metadata: result.getResultMetadata(),
             format: QrcodeResultFormat.create(
                 this.toHtml5QrcodeSupportedFormats(result.format)),
                 debugData: this.createDebugData()


### PR DESCRIPTION
Exposes metadata from zxing that includes the `byteSegments`. This would close #734 

From there, you could join all the byte segments like this:
```ts
const byteSegments = qrcodeResult.result.metadata?.get(ResultMetadataType.BYTE_SEGMENTS);
if (byteSegments) {
  const totalLength = byteSegments.reduce((prev, curr) => prev + curr.length, 0);
  const concatBytes = new Uint8Array(totalLength);
  let offset = 0;
  for (const byteSegment of byteSegments) {
    concatBytes.set(byteSegment, offset);
    offset += byteSegment.length;
  }
  return new TextDecoder().decode(concatBytes);
}
```