### PR TITLE
Disable picture-in-picture for video element

### DIFF
--- a/src/camera/core-impl.ts
+++ b/src/camera/core-impl.ts
@@ -164,6 +164,7 @@ class RenderedCameraImpl implements RenderedCamera {
         videoElement.style.display = "block";
         videoElement.muted = true;
         videoElement.setAttribute("muted", "true");
+        videoElement.setAttribute("disablePictureInPicture", "true");
         (<any>videoElement).playsInline = true;
         return videoElement;
     }


### PR DESCRIPTION
This pull request disables picture-in-picture mode on the video element used by html5-qrcode.

Some browsers automatically show a picture-in-picture button on HTML video elements. This can interfere with the QR code scanning UI and lead to unintended user interactions.

To improve the user experience and avoid unwanted PiP activation, this PR explicitly disables picture-in-picture.

# Changes
- Added a call to:
`videoElement.setAttribute("disablePictureInPicture", true);`
right after the video element is created / configured.

# Why this is needed
- Prevents accidental activation of PiP mode
- Avoids UI overlap with scanner controls
- Ensures a consistent scanning interface across browsers

# Additional notes
This change is non-breaking and only affects browsers that support the disablePictureInPicture attribute.