### PR TITLE
Fix published source map paths for npm package layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -Rf ./lib/* ./build/* ./meta/bundlesize/* ./meta/coverage/* ./.rpt2_cache  ./dist/* ./src/*.d.ts",
     "prebuild": "npm run clean",
     "postbuild": "cp -R ./third_party ./dist/third_party",
-    "build": "npm run build:es2015 && npm run build:esm && npm run build:esnext && npm run build:cjs && npm run build:umd && npm run build:typing && npm run build:copy",
+    "build": "npm run build:es2015 && npm run build:esm && npm run build:esnext && npm run build:cjs && npm run build:umd && npm run build:typing && npm run build:copy && npm run build:fix-sourcemaps",
     "build:es2015": "tsc --build tsconfig.lib-es2015.json",
     "build:esm": "tsc --build tsconfig.lib-esm.json",
     "build:esnext": "tsc --build tsconfig.lib-esm.json",
@@ -31,7 +31,8 @@
     "internal_release": "npm run build && cp dist/html5-qrcode.min.js minified/html5-qrcode.min.js",
     "release": "npm run build && cp dist/html5-qrcode.min.js minified/html5-qrcode.min.js && cd dist && npm publish",
     "release_windows": "npm run build && cp dist\\html5-qrcode.min.js minified\\html5-qrcode.min.js && cd dist && npm publish",
-    "doc_gen": "npx typedoc --excludePrivate src/index.ts"
+    "doc_gen": "npx typedoc --excludePrivate src/index.ts",
+    "build:fix-sourcemaps": "node scripts/fix-published-sourcemaps.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/fix-published-sourcemaps.js
+++ b/scripts/fix-published-sourcemaps.js
@@ -1,0 +1,70 @@
+/**
+ * Rewrites source map "sources" paths after the library build.
+ *
+ * TypeScript emits maps for dist/esm, dist/cjs, etc. When those folders are
+ * published at package root (esm/, cjs/, ...), each source path is one "../"
+ * segment too deep and bundlers resolve to node_modules/src/... instead of
+ * package-root src/.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const OUTPUT_DIRS = ['dist/esm', 'dist/cjs', 'dist/es2015'];
+
+function fixSourcePath(sourcePath) {
+  if (typeof sourcePath !== 'string' || !sourcePath.includes('/src/')) {
+    return sourcePath;
+  }
+  if (!sourcePath.startsWith('../')) {
+    return sourcePath;
+  }
+  return sourcePath.replace(/^\.\.\//, '');
+}
+
+function collectMapFiles(dir, files = []) {
+  if (!fs.existsSync(dir)) {
+    return files;
+  }
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectMapFiles(fullPath, files);
+    } else if (entry.isFile() && entry.name.endsWith('.js.map')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function patchSourceMapFile(mapFilePath) {
+  const map = JSON.parse(fs.readFileSync(mapFilePath, 'utf8'));
+  if (!Array.isArray(map.sources) || map.sources.length === 0) {
+    return false;
+  }
+
+  const nextSources = map.sources.map(fixSourcePath);
+  const changed = nextSources.some((source, index) => source !== map.sources[index]);
+  if (!changed) {
+    return false;
+  }
+
+  map.sources = nextSources;
+  fs.writeFileSync(mapFilePath, `${JSON.stringify(map)}\n`, 'utf8');
+  return true;
+}
+
+function main() {
+  const mapFiles = OUTPUT_DIRS.flatMap((dir) => collectMapFiles(path.join(PACKAGE_ROOT, dir)));
+  let patched = 0;
+
+  for (const mapFile of mapFiles) {
+    if (patchSourceMapFile(mapFile)) {
+      patched += 1;
+    }
+  }
+
+  console.log(`[fix-published-sourcemaps] Patched ${patched}/${mapFiles.length} source map file(s).`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Published npm packages expose \esm/\, \cjs/\, and \es2015/\ at the package root (via \cd dist && npm publish\), but TypeScript source maps still reference \../../src/...\ paths appropriate for \dist/esm/\ relative to the **repository** root.

Webpack \source-map-loader\ (used by Create React App) then resolves those paths to \
ode_modules/src/...\ instead of \
ode_modules/html5-qrcode/src/...\, producing 20+ ENOENT warnings on every dev build.

The package already ships \src/\; only the relative paths in \.map\ files are wrong.

## Fix

Add \scripts/fix-published-sourcemaps.js\ and run it at the end of \
pm run build\. It removes one \../\ segment from each \sources[]\ entry in published \.map\ files under \dist/esm\, \dist/cjs\, and \dist/es2015\.

## Repro (before fix)

\\\ash
npx create-react-app qr-test
cd qr-test
npm i html5-qrcode
# import { Html5Qrcode } from 'html5-qrcode' in App.js
npm start
\\\

Warnings like: \Failed to parse source map from .../node_modules/src/html5-qrcode.ts\

## Test plan

- [ ] \
pm run build\ completes and \uild:fix-sourcemaps\ reports patched map files
- [ ] Import package in CRA app — no source-map-loader ENOENT warnings
- [ ] Browser devtools can still map bundled code to \src/\ TypeScript sources